### PR TITLE
Add last modification date

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,11 +16,12 @@ after_success:
 - python3 ./scripts/createManifest.py -outputFile=manifest -inputFolder=alerts
 - python3 ./scripts/createManifest.py -format=js -outputFile=examplemanifest -inputFolder=examples
 - python3 ./scripts/createManifest.py -format=js -outputFile=manifest -inputFolder=alerts
+- date --iso-8601=seconds > ./output/lastmodified.txt
 
 deploy:
   provider: script
   skip_cleanup: true
-  script: rsync -avz -e "ssh -i useralerts" ./output/examplemanifest.json ./output/manifest.json ./output/examplemanifest.js ./output/manifest.js ./readers/alerts.html autotest@firmware.ardupilot.org:~/APM/buildlogs/binaries/useralerts/
+  script: rsync -avz -e "ssh -i useralerts" ./output/lastmodified.txt ./output/examplemanifest.json ./output/manifest.json ./output/examplemanifest.js ./output/manifest.js ./readers/alerts.html autotest@firmware.ardupilot.org:~/APM/buildlogs/binaries/useralerts/
   on:
     branch: master
 

--- a/scripts/createManifest.py
+++ b/scripts/createManifest.py
@@ -8,6 +8,7 @@ import os
 import pathlib
 import json
 import argparse
+import subprocess
 
 if __name__ == "__main__":
     # Create the parser
@@ -35,9 +36,12 @@ if __name__ == "__main__":
         data = None
 
         if fileAbs.endswith(".json") and "BAD" not in file:
+            # get last modified date
+            dateMod = subprocess.check_output(["git", "log", "-1", "--date=iso-strict", "--pretty=%cI", fileAbs]).decode("utf-8").strip()
             with open(fileAbs) as json_file:
                 try:
                     data = json.load(json_file)
+                    data["lastmodified"] = dateMod
                     manifestData[file] = data
                     print("Included {0}".format(file))
                     numAlerts += 1


### PR DESCRIPTION
This PR adds a "last modification date" at both a per-alert and entire manifest level.

- Each user alert will automatically have a "lastmodified" field added upon manifest generation. 
- A ``lastmodified.txt`` file will be uploaded alongside the manifest, containg the date&time of manifest generation

Fixes #5 