### PR TITLE
Add User Alert 0002

### DIFF
--- a/alerts/UA00002.json
+++ b/alerts/UA00002.json
@@ -1,15 +1,15 @@
 {
   "dateRaised": 20201028,
   "affectedFirmware": ["all"],
-  "hardwareLimited": [],
-  "description": "When using SBUS output, if the RC receiver is lost the IOMCU will invert the SBUS output momentarily whilst searching for an FPort input. This can lead to a loss of signal on the SBUS output port. This only affects boards with an IOMCU",
-  "mitigation": "Do not use the SBUS output port",
+  "hardwareLimited": ["CUAVv5", "CubeBlack", "CubeBlack+", "CubeGreen-solo", "CubeOrange", "CubePurple", "CubeSolo", "CubeYellow", "DrotekP3Pro", "Durandal", "fmuv2", "fmuv3", "fmuv5", "mRoX21", "mRoX21-777", "Pix32v5", "Pixhawk1", "Pixhawk1-1M", "Pixhawk4"],
+  "description": "When using SBUS output, if the RC receiver is lost the IOMCU will invert the SBUS output momentarily whilst searching for an RC input. This can lead to a loss of signal on the SBUS output port. This only affects boards with an IOMCU that use the default SBUS Output port.",
+  "mitigation": "Do not use the default SBUS OUT port. Use an alternative UART for SBUS Output.",
   "fixCommit": ["5980d3bb21fc3a258f4bde6c98209dec7b82490b", "8e57677c00c4df5f46f9e4def2d8c77a9da8e47b"],
-  "dateResolved": null,
+  "dateResolved": 20201103,
   "linkedIssue": "https://github.com/ArduPilot/ardupilot/issues/15516",
   "linkedInfo": [],
   "linkedPR": "https://github.com/ArduPilot/ardupilot/pull/15523",
   "versionFrom": {"copter": "4.0.4", "plane": "4.0.6"},
-  "versionFixed": {"copter": "4.0.5"},
+  "versionFixed": {"copter": "4.0.5", "plane": "4.0.7"},
   "criticality": 4
 }

--- a/alerts/UA00002.json
+++ b/alerts/UA00002.json
@@ -1,9 +1,11 @@
 {
   "dateRaised": 20201028,
-  "affectedFirmware": ["all"],
+  "affectedMasterFirmware": ["all"],
+  "affectedStableFirmware": ["copter", "plane"],
   "hardwareLimited": ["CUAVv5", "CubeBlack", "CubeBlack+", "CubeGreen-solo", "CubeOrange", "CubePurple", "CubeSolo", "CubeYellow", "DrotekP3Pro", "Durandal", "fmuv2", "fmuv3", "fmuv5", "mRoX21", "mRoX21-777", "Pix32v5", "Pixhawk1", "Pixhawk1-1M", "Pixhawk4"],
   "description": "When using SBUS output, if the RC receiver is lost the IOMCU will invert the SBUS output momentarily whilst searching for an RC input. This can lead to a loss of signal on the SBUS output port. This only affects boards with an IOMCU that use the default SBUS Output port.",
-  "mitigation": "Do not use the default SBUS OUT port. Use an alternative UART for SBUS Output.",
+  "preReleaseMitigation": "Do not use the default SBUS OUT port. Use an alternative UART for SBUS Output.",
+  "postReleaseMitigation": "Upgrade to ArduCopter 4.0.5 (or later) or ArduPlane 4.0.7 (or later).",
   "fixCommit": ["5980d3bb21fc3a258f4bde6c98209dec7b82490b", "8e57677c00c4df5f46f9e4def2d8c77a9da8e47b"],
   "dateResolved": 20201103,
   "linkedIssue": "https://github.com/ArduPilot/ardupilot/issues/15516",

--- a/alerts/UA00002.json
+++ b/alerts/UA00002.json
@@ -1,7 +1,6 @@
 {
   "dateRaised": 20201028,
-  "affectedLatestFirmware": ["all"],
-  "affectedStableFirmware": ["copter", "plane"],
+  "affectedFirmware": ["copter", "plane"],
   "hardwareLimited": ["CUAVv5", "CubeBlack", "CubeBlack+", "CubeGreen-solo", "CubeOrange", "CubePurple", "CubeSolo", "CubeYellow", "DrotekP3Pro", "Durandal", "fmuv2", "fmuv3", "fmuv5", "mRoX21", "mRoX21-777", "Pix32v5", "Pixhawk1", "Pixhawk1-1M", "Pixhawk4"],
   "description": "When using SBUS output, if the RC receiver is lost the IOMCU will invert the SBUS output momentarily whilst searching for an RC input. This can lead to a loss of signal on the SBUS output port. This only affects boards with an IOMCU that use the default SBUS Output port.",
   "mitigation": "Upgrade to ArduCopter 4.0.5 (or later) or ArduPlane 4.0.7 (or later). If unable to upgrade, use an alternative UART Port for SBUS Output instead of the default SBUS OUT port.",

--- a/alerts/UA00002.json
+++ b/alerts/UA00002.json
@@ -1,11 +1,10 @@
 {
   "dateRaised": 20201028,
-  "affectedMasterFirmware": ["all"],
+  "affectedLatestFirmware": ["all"],
   "affectedStableFirmware": ["copter", "plane"],
   "hardwareLimited": ["CUAVv5", "CubeBlack", "CubeBlack+", "CubeGreen-solo", "CubeOrange", "CubePurple", "CubeSolo", "CubeYellow", "DrotekP3Pro", "Durandal", "fmuv2", "fmuv3", "fmuv5", "mRoX21", "mRoX21-777", "Pix32v5", "Pixhawk1", "Pixhawk1-1M", "Pixhawk4"],
   "description": "When using SBUS output, if the RC receiver is lost the IOMCU will invert the SBUS output momentarily whilst searching for an RC input. This can lead to a loss of signal on the SBUS output port. This only affects boards with an IOMCU that use the default SBUS Output port.",
-  "preReleaseMitigation": "Do not use the default SBUS OUT port. Use an alternative UART for SBUS Output.",
-  "postReleaseMitigation": "Upgrade to ArduCopter 4.0.5 (or later) or ArduPlane 4.0.7 (or later).",
+  "mitigation": "Upgrade to ArduCopter 4.0.5 (or later) or ArduPlane 4.0.7 (or later). If unable to upgrade, use an alternative UART Port for SBUS Output instead of the default SBUS OUT port.",
   "fixCommit": ["5980d3bb21fc3a258f4bde6c98209dec7b82490b", "8e57677c00c4df5f46f9e4def2d8c77a9da8e47b"],
   "dateResolved": 20201103,
   "linkedIssue": "https://github.com/ArduPilot/ardupilot/issues/15516",

--- a/alerts/UA00002.json
+++ b/alerts/UA00002.json
@@ -1,0 +1,15 @@
+{
+  "dateRaised": 20201028,
+  "affectedFirmware": ["all"],
+  "hardwareLimited": [],
+  "description": "When using SBUS output, if the RC receiver is lost the IOMCU will invert the SBUS output momentarily whilst searching for an FPort input. This can lead to a loss of signal on the SBUS output port. This only affects boards with an IOMCU",
+  "mitigation": "Do not use the SBUS output port",
+  "fixCommit": ["5980d3bb21fc3a258f4bde6c98209dec7b82490b", "8e57677c00c4df5f46f9e4def2d8c77a9da8e47b"],
+  "dateResolved": null,
+  "linkedIssue": "https://github.com/ArduPilot/ardupilot/issues/15516",
+  "linkedInfo": [],
+  "linkedPR": "https://github.com/ArduPilot/ardupilot/pull/15523",
+  "versionFrom": {"copter": "4.0.4", "plane": "4.0.6"},
+  "versionFixed": {"copter": "4.0.5"},
+  "criticality": 4
+}


### PR DESCRIPTION
From the Discord chat with @rmackay9.

This concerns the issue over at https://github.com/ArduPilot/ardupilot/issues/15516, where the user may lose SBUS output (and any servos using it). This is related to the implementation of FPort.

I've done what research I can of the issue, but I'd like to get a confirmation of the following:
1) This appears to only be limited to flight controllers with an IOMCU.
2) For the rover, sub and tracker firmwares, there has been no stable release that contains this issue.