### PR TITLE
Newfield2

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ See ArduPilot Wiki (https://ardupilot.org/dev/docs/user-alerts-developer.html)
 
 Simply querying the site (see below for URL's) will return a json array or javascript variable of all user alerts.
 These can then be filtered by the ``versionFrom``, ``versionFixed``,
-``affectedFirmware`` and ``hardwareLimited`` fields to match with the
+``affectedStableFirmware`` and ``hardwareLimited`` fields to match with the
 user's autopilot and display any relevant user alerts.
 
 There are URL's for both an *example* manifest (for testing purposes) and the

--- a/alert.schema.json
+++ b/alert.schema.json
@@ -6,7 +6,8 @@
     "default": {},
     "required": [
         "dateRaised",
-        "affectedFirmware",
+        "affectedStableFirmware",
+        "affectedLatestFirmware",
         "hardwareLimited",
         "description",
         "mitigation",
@@ -31,11 +32,27 @@
                 20190210
             ]
         },
-        "affectedFirmware": {
-            "$id": "#/properties/affectedFirmware",
+        "affectedStableFirmware": {
+            "$id": "#/properties/affectedStableFirmware",
             "type": "array",
-            "title": "affectedFirmware",
-            "description": "Which ArduPilot firmware is affected. Use comma separated value to specify multiple vehicles if 'all' does not work.",
+            "title": "affectedStableFirmware",
+            "description": "Which stable ArduPilot firmware is affected. Use comma separated value to specify multiple vehicles if 'all' does not work.",
+            "default": [],
+            "examples": [
+                [
+                    "all"
+                ]
+            ],
+            "additionalItems": false,
+            "items": {
+                "additionalItems": { "type": "string", "enum": ["copter", "sub", "antenna", "plane", "rover", "AP_Periph", "all"]}
+            }
+        },
+        "affectedLatestFirmware": {
+            "$id": "#/properties/affectedLatestFirmware",
+            "type": "array",
+            "title": "affectedLatestFirmware",
+            "description": "Which latest ArduPilot firmware is affected. Use comma separated value to specify multiple vehicles if 'all' does not work.",
             "default": [],
             "examples": [
                 [

--- a/alerts/UA00001.json
+++ b/alerts/UA00001.json
@@ -1,6 +1,7 @@
 {
   "dateRaised": 20200929,
-  "affectedFirmware": ["all"],
+  "affectedLatestFirmware": ["all"],
+  "affectedStableFirmware": ["all"],
   "hardwareLimited": [],
   "description": "When using interrupt driven inputs on STM32 based boards, if an external hardware failure occurs that generates an extremely high interrupt rate (over 500,000 interrupts per second) the flight controller can become overloaded and cease to function. This affects the following types of inputs: RPM sensor with RPM_TYPE 1 or 2, Camera feedback with a CAM_FEEDBACK_PIN, Wheel encoders with WENC_TYPE=1, liquid fuel flow monitors with BATT_MONITOR=11 or 12, PWM rangefinder with RFND type 5, 22 or 30, RSSI with RSSI_TYPE=4.",
   "mitigation": "Disable the parameter associated with the interrupt input",

--- a/examples/BAD001.txt
+++ b/examples/BAD001.txt
@@ -1,6 +1,7 @@
 {
   "dateRaised": 20200110,
-  "affectedFirmware": ["all"],
+  "affectedStableFirmware": ["all"],
+  "affectedLatestFirmware": ["all"],
   "hardwareLimited": [],
   "description": "If FrSky SPort Passthrough is enabled on a Telemetry port, a race condition may cause an in-air lockup of the Autopilot",
   "mitigation": "Disable FrSky SPort Passthrough by setting the SERIALx_PROTOCOL parameters to anything but 10.",

--- a/examples/BAD002.json
+++ b/examples/BAD002.json
@@ -1,6 +1,7 @@
 {
   "dateRaised": 20200110,
-  "affectedFirmware": ["all"],
+  "affectedLatestFirmware": ["all"],
+  "affectedStableFirmware": ["all"],
   "hardwareLimited": []
   "description": "If FrSky SPort Passthrough is enabled on a Telemetry port, a race condition may cause an in-air lockup of the Autopilot",
   "mitigation": "Disable FrSky SPort Passthrough by setting the SERIALx_PROTOCOL parameters to anything but 10.",

--- a/examples/BAD003.json
+++ b/examples/BAD003.json
@@ -1,6 +1,7 @@
 {
   "dateRaised": 20200110,
-  "affectedFirmware": ["all"],
+  "affectedLatestFirmware": ["all"],
+  "affectedStableFirmware": ["all"],
   "hardwareLimited": [],
   "description": "If FrSky SPort Passthrough is enabled on a Telemetry port, a race condition may cause an in-air lockup of the Autopilot",
   "mitigation": "Disable FrSky SPort Passthrough by setting the SERIALx_PROTOCOL parameters to anything but 10.",

--- a/examples/BAD004.json
+++ b/examples/BAD004.json
@@ -1,6 +1,7 @@
 {
   "dateRaised": "testbad",
-  "affectedFirmware": 2000,
+  "affectedLatestFirmware": 2000,
+  "affectedStableFirmware": ["copter", "plane", "rover"],
   "hardwareLimited": [],
   "description": "If FrSky SPort Passthrough is enabled on a Telemetry port, a race condition may cause an in-air lockup of the Autopilot",
   "mitigation": 20,

--- a/examples/EX00001.json
+++ b/examples/EX00001.json
@@ -1,6 +1,7 @@
 {
   "dateRaised": 20190101,
-  "affectedFirmware": ["plane"],
+  "affectedLatestFirmware": ["plane"],
+  "affectedStableFirmware": ["copter", "plane", "rover"],
   "hardwareLimited": [],
   "description": "This is an example open issue for Plane only, V3.9.5 and above",
   "mitigation": "Put the temporary mitigation here",

--- a/examples/EX00002.json
+++ b/examples/EX00002.json
@@ -1,6 +1,7 @@
 {
   "dateRaised": 20190210,
-  "affectedFirmware": ["all"],
+  "affectedLatestFirmware": ["all"],
+  "affectedStableFirmware": ["all"],
   "hardwareLimited": ["Pixhawk1-1M"],
   "description": "This is an example issue that only affects the Pixhawk1-1M boards",
   "mitigation": "Do something",

--- a/examples/EX00003.json
+++ b/examples/EX00003.json
@@ -1,6 +1,7 @@
 {
   "dateRaised": 20190624,
-  "affectedFirmware": ["all"],
+  "affectedLatestFirmware": ["all"],
+  "affectedStableFirmware": ["all"],
   "hardwareLimited": [],
   "description": "Another example that is only resolved for plane and copter, other firmwares outstanding",
   "mitigation": "Do something else until a fixed firmware is released",

--- a/examples/EX00004.json
+++ b/examples/EX00004.json
@@ -1,6 +1,7 @@
 {
   "dateRaised": 20190624,
-  "affectedFirmware": ["all"],
+  "affectedLatestFirmware": ["all"],
+  "affectedStableFirmware": ["all"],
   "hardwareLimited": [],
   "description": "Interference from an external cable connected to the I2C bus may cause a flood of interrupts on the Flight Controller, locking it up",
   "mitigation": "Do not use I2C devices where possible. Ensure all I2C cables are short in length and not near any RF noise sources",

--- a/examples/EX00005.json
+++ b/examples/EX00005.json
@@ -1,6 +1,7 @@
 {
   "dateRaised": 20200110,
-  "affectedFirmware": ["copter", "plane", "rover"],
+  "affectedLatestFirmware": ["all"],
+  "affectedStableFirmware": ["copter", "plane", "rover"],
   "hardwareLimited": [],
   "description": "If FrSky SPort Passthrough is enabled on a Telemetry port, a race condition may cause an in-air lockup of the Autopilot",
   "mitigation": "Disable FrSky SPort Passthrough by setting the SERIALx_PROTOCOL parameters to anything but 10.",

--- a/json_test.py
+++ b/json_test.py
@@ -67,7 +67,8 @@ def checkFile(fileAbs):
         print("Bad field: dateRaised")
         assert False
 
-    assert "affectedFirmware" in data and isinstance(data["affectedFirmware"], list) and len(data["affectedFirmware"]) > 0
+    assert "affectedStableFirmware" in data and isinstance(data["affectedStableFirmware"], list) and len(data["affectedStableFirmware"]) > 0
+    assert "affectedLatestFirmware" in data and isinstance(data["affectedLatestFirmware"], list) and len(data["affectedLatestFirmware"]) > 0
     assert "hardwareLimited" in data and isinstance(data["hardwareLimited"], list)
     assert "description" in data and isinstance(data["description"], str)
     assert "mitigation" in data and isinstance(data["mitigation"], str)

--- a/readers/alerts.html
+++ b/readers/alerts.html
@@ -74,9 +74,9 @@ function selectVeh(sel)
     var table = document.getElementById('alertsTable');
     var content = '';
     for (var key in userAlerts) {
-            for (var i = 0, len = userAlerts[key].affectedFirmware.length; i < len; i++) {
-                //console.log(userAlerts[key].affectedFirmware[i]);
-              if (userAlerts[key].affectedFirmware[i] === "all" || userAlerts[key].affectedFirmware[i] === sel.value) {
+            for (var i = 0, len = userAlerts[key].affectedStableFirmware.length; i < len; i++) {
+                //console.log(userAlerts[key].affectedStableFirmware[i]);
+              if (userAlerts[key].affectedStableFirmware[i] === "all" || userAlerts[key].affectedStableFirmware[i] === sel.value) {
                     content += '<tr id="' + key + '">';
                     content += '<td>' + key + '</td>';
                     content += '<td>' + userAlerts[key].dateRaised + '</td>';

--- a/readers/webrender.html
+++ b/readers/webrender.html
@@ -78,9 +78,9 @@ function selectVeh(sel)
     var table = document.getElementById('alertsTable');
     var content = '';
     for (var key in userAlerts) {
-            for (var i = 0, len = userAlerts[key].affectedFirmware.length; i < len; i++) {
-                //console.log(userAlerts[key].affectedFirmware[i]);
-              if (userAlerts[key].affectedFirmware[i] === "all" || userAlerts[key].affectedFirmware[i] === sel.value) {
+            for (var i = 0, len = userAlerts[key].affectedStableFirmware.length; i < len; i++) {
+                //console.log(userAlerts[key].affectedStableFirmware[i]);
+              if (userAlerts[key].affectedStableFirmware[i] === "all" || userAlerts[key].affectedStableFirmware[i] === sel.value) {
                     content += '<tr id="' + key + '">';
                     content += '<td>' + key + '</td>';
                     content += '<td>' + userAlerts[key].dateRaised + '</td>';

--- a/template.json
+++ b/template.json
@@ -1,6 +1,7 @@
 {
   "dateRaised": YYYYMMDD,
-  "affectedFirmware": [],
+  "affectedStableFirmware": [],
+  "affectedLatestFirmware": [],
   "hardwareLimited": [],
   "description": "",
   "mitigation": "",


### PR DESCRIPTION
This PR splits the affectedFirmware field into affectedStableFirmware and affectedLatestFirmware.

affectedStableFirmware = list of stable ArduPilot firmwares affected by User Alert
affectedLatestFirmware = list of latest (ie https://firmware.ardupilot.org/Plane/latest/) ArduPilot firmwares affected by User Alert

The split is required as some alerts may only affect and be fixed within a single release for a firmware.

An example of this is https://github.com/ArduPilot/useralerts/pull/10. Where the FPort feature caused a safety issue and was promptly patched.
For Copter, issue affects v4.0.5 and fixed in v4.0.6
For Plane, issue affects v4.0.6 and fixed in v4.0.7
For Rover, Sub and Antenna Tracker: Stable version not affect, as FPort was added and fixed within the same version. Anyone running master (latest) would be affected by the issue though, until they pull in the fix.